### PR TITLE
fix: remove default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features
 
   release:
       name: Semantic Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Steven Bosnick <sbosnick@sympatico.ca>"]
 edition = "2018"
 
 [features]
-default = ["mio-fd", "net-fd", "tokio-fd"]
 net-fd = ["nix", "tracing"]
 mio-fd = ["net-fd", "mio"]
 tokio-fd = ["mio-fd", "tokio", "socket2", "pin-project", "futures-core", "futures-util"]


### PR DESCRIPTION
The mio-fd, net-fd, and tokio-fd features are now opt-in, rather
than opt-out. The change to the CI workflow ensures that the tests
are still run for all features.

BREAKING CHANGE: remove mio-fd, net-fd, and tokio-fd as default features

All features are now opt-in features. Crates that previously relied on these
features will now have to explicty name the features in the dependencies
entry for for "fd-queue" in their "Cargo.toml" files.

Fixes: #5