### PR TITLE
ci: split CI workflow and the Release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   pull_request:
-  push:
     branches:
       - master
       - alpha
@@ -25,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Rust (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
@@ -59,28 +58,3 @@ jobs:
         with:
           command: test
           args: --all-features
-
-  release:
-      name: Semantic Release
-      if: github.event_name == 'push'
-      runs-on: ubuntu-latest
-      needs: ['test']
-
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v1
-
-          - name: Install Rust Stable
-            uses: actions-rs/toolchain@v1
-            with:
-                profile: minimal
-                toolchain: stable
-                override: true
-
-          - name: Semantic Release
-            uses: cycjimmy/semantic-release-action@v2
-            with:
-                semantic_version: 17.1.1
-                dry_run: true
-            env:
-                GITHUB_TOKEN: ${{ secrets.SEM_REL_GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+      - alpha
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+    release:
+        name: Semantic Release
+        runs-on: ubuntu-latest
+
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v2
+
+          - name: Install Rust Stable
+            uses: actions-rs/toolchain@v1
+            with:
+                profile: minimal
+                toolchain: stable
+                override: true
+
+          - name: Stable Test
+            uses: actions-rs/cargo@v1
+            with:
+                command: test
+                args: --all-features
+
+          - name: Semantic Release
+            uses: cycjimmy/semantic-release-action@v2
+            with:
+                semantic_version: 17.1.1
+                dry_run: true
+            env:
+                GITHUB_TOKEN: ${{ secrets.SEM_REL_GH_TOKEN }}
+
+


### PR DESCRIPTION
The CI workflow runs on pull requests and runs the test suite on
the matrix of stable, beta, and nightly and on the MSRV (currently
1.39). The Release workflow runs on push's to the master or alpha
branches. As these are protected branches this means the the Release
workflow runs when a pull request is merged into one of these branches.

The Release workflow does not re-run the full test suite that is run
in the CI workflow, but rather just runs the tests on stable Rust. This
is designed to support the current low-velocity change workflow of a
single active pull request at a time but will break down once we start
having multiple active pull requests at a time. At that point the Release
workflow should be extended to test on the same matrix as the CI
workflow. We could also consider using [bors](https://bors.tech/).