### PR TITLE
ci(release): change install of semantic-release-rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,10 @@ jobs:
                 override: true
 
           - name: Install Semantic Release Rust
-            uses: actions-rs/install@v0.1
+            uses: actions-rs/cargo@v1
             with:
-                crate: semantic-release-rust
+                command: install
+                args: --git https://github.com/sbosnick/semantic-release-rust --tag v1.0.0-alpha.5
 
           - name: Stable Test
             uses: actions-rs/cargo@v1


### PR DESCRIPTION
Change to use "cargo install --git ..." instead of attempting to
install from crates.io since the crates.io install fails. That
failure appears to be related to semantic-release-rust currently
only having prerelease versions.