### PR TITLE
feat(release): add information for initial (pre) release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
             id: semantic
             with:
                 semantic_version: 17.1.1
-                dry_run: true
                 extra_plugins: |
                     @semantic-release/exec@5.0
             env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ name = "fd-queue"
 version = "0.1.0"
 authors = ["Steven Bosnick <sbosnick@sympatico.ca>"]
 edition = "2018"
+description = "A library to support fd passing on Unix sockets."
+readme = "README.md"
+repository = "https://github.com/sbosnick/fd-queue"
+license = "MIT OR Apache-2.0"
+keywords = ["fd", "unix", "socket", "domain"]
+categories = ["asynchronous", "os::unix-apis"]
 
 [features]
 net-fd = ["nix", "tracing"]

--- a/README.md
+++ b/README.md
@@ -6,13 +6,96 @@
 ---
 
 fd-queue provides traits for enqueuing and dequeuing file descriptors and
-implementations of those traits for different types of unix sockets.
+implementations of those traits for different types of Unix sockets.
 Specifically fd-queue provides a blocking implementation, a non-blocking
 implementation base on [mio], and a non-blocking implementation based on
 [tokio].
 
 [mio]: https://crates.io/crates/mio
 [tokio]: https://crates.io/crates/tokio
+
+## Usage
+
+Add this to your `Cargo.toml`
+
+```toml
+[dependencies]
+fd-queue = {version = "1.0.0-alpha.1", features = ["net-fd"]}
+```
+
+This enables the blocking implementation of the traits for enqueuing and
+dequeuing file descriptors. See below for the other features. You can then
+use the library as follows:
+
+```rust
+use std::{
+    fs::File,
+    io::prelude::*,
+    os::unix::io::FromRawFd,
+};
+use fd_queue::{EnqueueFd, DequeueFd, UnixStream};
+
+let (mut sock1, mut sock2) = UnixStream::pair()?;
+
+// sender side
+let file: File = ...
+sock1.enqueue(&file).expect("Can't enquque the file descriptor.");
+sock1.write(b"a")?;
+sock1.flush()?;
+
+//receiver side
+let mut buf = [0u8; 1];
+sock2.read(&mut buf)?;
+let fd = sock2.dequeue().expect("Can't dequeue the file descriptor.");
+let file2 = unsafe { File::from_raw_fd(fd) };
+```
+
+## Features
+Usage of the library with the default features will include only the basic
+trait definitions `DequeueFd` and `EnqueueFd` together with their supporting
+types. With the default features there will be no implementations of the basic
+traits. To include implementations of the traits enable the following features:
+
+| Feature  | Implementation | Additional Traits          |
+----------------------------------------------------------
+| net-fd   | blocking       | `Read`, `Write`            |
+| mio-fd   | non-blocking   | `Read`, `Write`, `Evented` |
+| tokio-fd | non-blocking   | `AsyncRead`, `AsyncWrite`  |
+
+## Rust Version Requirements
+The library will always support the Rust version that is two earlier
+than the current stable version. The current Minimum Supported Rust
+Version (MSRV) is 1.39.0. Any change to the MSRV will be treated as a
+breaking change for Semantic Version purposes.
+
+## Semantic Version and Release
+This library follows [semantic versioning][semver], but without [Rust's
+modification][rust-semver] to pre-1.0.0 minor version numbers. All
+breaking changes will result in increasing the major version number.
+
+This library also uses [Semantic Release][semrel] for its release process
+which means that it will not have any pre-1.0.0 releases (for the reasons
+described [here][no-pre-1.0.0]).
+
+The first non-pre-release version of the library will be version 1.0.0. This
+does not signal that the library is production ready or that we will attempt
+to avoid breaking changes. It rather signals exactly what the [Semantic Versioning
+Specification][semver] says it does: there won't be any backward incompatible
+changes until version 2.0.0 (see [here][semver-8]).
+
+For a signal of the maturity of the library see the next heading which will be
+updated as the library matures.
+
+[no-pre-1.0.0]: https://semantic-release.gitbook.io/semantic-release/support/faq#can-i-set-the-initial-release-version-of-my-package-to-0-0-1
+[rust-semver]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field
+[semrel]: https://semantic-release.gitbook.io/semantic-release/
+[semver]: https://semver.org/
+[semver-8]: https://semver.org/#spec-item-8
+
+## Maturity
+This library is an initial, experimental implementation that has not had any
+use in production. You should expect breaking changes (with an appropriate change
+in [semantic version][semver]) as the library matures.
 
 ## License
 


### PR DESCRIPTION
Add descriptive fields to the `[package]` table of `Cargo.toml` and
addtional descritive information to `README.md`. Remove the `dry-run`
argument for the Semantic Release step of the release workflow.

Barring errors in the release workflow, this should result in the
initial release of the library.