### PR TITLE
fix(release): change process for committing version number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     release:
         name: Semantic Release
         runs-on: ubuntu-latest
+        if: github.actor != 'sbosnick-bot'
 
         steps:
           - name: Checkout
@@ -45,32 +46,7 @@ jobs:
                 semantic_version: 17.1.1
                 extra_plugins: |
                     @semantic-release/exec@5.0
+                    @semantic-release/git@9.0
             env:
                 GITHUB_TOKEN: ${{ secrets.SEM_REL_GH_TOKEN }}
                 CARGO_REGISTRY_TOKEN: ${{ secrets.SEMREL_CRATES_IO }}
-
-          - name: Create Pull Request
-            uses: peter-evans/create-pull-request@v3.1.0
-            if: steps.semantic.outputs.new_release_published == 'true'
-            id: create-pr
-            with:
-                commit-message: 'chore(release): version ${{ steps.semantic.outputs.new_release_version }}'
-                committer: sbosnick-bot <sbosnick@gmail.com>
-                author: sbosnick-bot <sbosnick@gmail.com>
-                branch: release-bot/${{ steps.semantic.outputs.new_release_version }}
-                labels: "automerge"
-                title: 'chore(release): version ${{ steps.semantic.outputs.new_release_version }}'
-                body: >
-                    Version bump in Crates.io files for release
-                    [${{ steps.semantic.outputs.new_release_version }}](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.semantic.outputs.new_release_version }})
-
-
-                    [skip ci]
-
-          - name: Merge Pull Request
-            uses: sudo-bot/action-pull-request-merge@v1.1.1
-            if: steps.semantic.outputs.new_release_published == 'true' && steps.create-pr.outputs.pull-request-number != ''
-            with:
-                github-token: ${{ secrets.GITHUB_TOKEN }}
-                number: ${{ steps.create-pr.outputs.pull-request-number }}
-                merge-method: squash

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -6,3 +6,5 @@ plugins:
       - verifyConditionsCmd: "semantic-release-rust verify-conditions"
         prepareCmd: "semantic-release-rust prepare ${nextRelease.version}"
         publishCmd: "semantic-release-rust publish"
+    - - '@semantic-release/git'
+      - assets: Cargo.toml


### PR DESCRIPTION
The steps of the semantic release plugins will change the version number
in the Cargo.toml file. The old means of pushing the changes Cargo.toml
file to GitHub was to create a pull request and then attempt to merge it.
This created difficulites with the required status checks.

Change the method of pushing the altered Cargo.toml file to use the
semantic-release/git plugin. This assumes that the sbosnick-bot that
is used to authenticate semantic release is an administrator and that the
required status checks can be by-passed for administrators.