### PR TITLE
Update mio to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tokio-fd = ["tracing", "tokio", "pin-project", "futures-core", "futures-util"]
 
 [dependencies]
 tracing = {version = "0.1.15", optional = true}
-mio = {version = "0.8.4", optional = true, features = ["os-poll", "os-ext", "net"]}
+mio = {version = "0.8.4", optional = true, features = ["net"]}
 tokio = {version = "1.0.0", optional = true, features = ["net"]}
 pin-project = {version = "1.0.0", optional = true}
 futures-core = {version = "0.3.5", optional = true}
@@ -30,6 +30,7 @@ tempfile = "3.1.0"
 assert_matches = "1.3.0"
 tokio = {version = "1.0.0", features = ["rt-multi-thread", "macros", "io-util"]}
 tokio-test = "0.4.2"
+mio = {features = ["os-poll", "os-ext"]}
 
 [build-dependencies]
 libc = "0.2.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tokio-fd = ["tracing", "tokio", "pin-project", "futures-core", "futures-util"]
 
 [dependencies]
 tracing = {version = "0.1.15", optional = true}
-mio = {version = "0.6.22", optional = true}
+mio = {version = "0.8.4", optional = true, features = ["os-poll", "os-ext", "net"]}
 tokio = {version = "1.0.0", optional = true, features = ["net"]}
 pin-project = {version = "1.0.0", optional = true}
 futures-core = {version = "0.3.5", optional = true}


### PR DESCRIPTION
close #53 

changes:
  - update mio to 0.8 in Cargo.toml
  - mio.rs now uses newer 0.8 mio API

My implementation removes the dependency `fd_queue::mio::UnixStream` on `fd_queue::net::UnixStream`. Much like how `fd_queue::tokio::UnixStream` is implemented. 