### PR TITLE
feat(biquque): make the queue size generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures-core = {version = "0.3.5", optional = true}
 futures-util = {version = "0.3.5", optional = true}
 libc = {version = "0.2.80", features = ["extra_traits"]}
 num-traits = "0.2.14"
+smallvec = "1.10.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/biqueue.rs
+++ b/src/biqueue.rs
@@ -95,7 +95,7 @@ impl<const SIZE: usize> Push<Fd> for BiQueue<SIZE> {
     }
 }
 
-impl EnqueueFd for BiQueue {
+impl<const SIZE: usize> EnqueueFd for BiQueue<SIZE> {
     fn enqueue(&mut self, fd: &impl AsRawFd) -> std::result::Result<(), QueueFullError> {
         if self.outfd.len() >= Self::FD_QUEUE_SIZE {
             warn!(source = "UnixStream", event = "enqueue", condition = "full");

--- a/src/biqueue.rs
+++ b/src/biqueue.rs
@@ -17,11 +17,15 @@ use std::{
 };
 
 use ::tracing::{trace, warn};
+use smallvec::SmallVec;
 
 use crate::{DequeueFd, EnqueueFd, QueueFullError};
 use iomsg::{cmsg_buffer_fds_space, Fd, MsgHdr};
 
 mod iomsg;
+
+/// The default size of the inbound and outbound fd queues.
+pub const DEFAULT_FD_QUEUE_SIZE: usize = 2;
 
 /// The Bi-directional queue for fd passing.
 ///
@@ -30,7 +34,7 @@ mod iomsg;
 /// and [`BiQueue::read_vectored`] methods. The inbound and outbound queues are accessed
 /// through the [`EnqueueFd`] and [`DequeueFd`] trait impl's.
 #[derive(Debug)]
-pub struct BiQueue {
+pub struct BiQueue<const SIZE: usize = DEFAULT_FD_QUEUE_SIZE> {
     infd: VecDeque<Fd>,
     outfd: Vec<RawFd>,
 }
@@ -47,8 +51,8 @@ trait Push<A> {
 
 // === impl Biqueue ===
 
-impl BiQueue {
-    pub const FD_QUEUE_SIZE: usize = 2;
+impl<const SIZE: usize> BiQueue<SIZE> {
+    pub const FD_QUEUE_SIZE: usize = SIZE;
 
     pub fn new() -> Self {
         BiQueue {
@@ -58,7 +62,7 @@ impl BiQueue {
     }
 
     pub fn write_vectored(&mut self, fd: impl AsRawFd, bufs: &[IoSlice]) -> io::Result<usize> {
-        send_fds(fd.as_raw_fd(), bufs, self.outfd.drain(..))
+        Self::send_fds(fd.as_raw_fd(), bufs, self.outfd.drain(..))
     }
 
     pub fn read_vectored(
@@ -66,11 +70,11 @@ impl BiQueue {
         fd: impl AsRawFd,
         bufs: &mut [IoSliceMut],
     ) -> io::Result<usize> {
-        recv_fds(fd.as_raw_fd(), bufs, self)
+        Self::recv_fds(fd.as_raw_fd(), bufs, self)
     }
 }
 
-impl DequeueFd for BiQueue {
+impl<const SIZE: usize> DequeueFd for BiQueue<SIZE> {
     fn dequeue(&mut self) -> Option<RawFd> {
         let result = self.infd.pop_front().map(|fd| fd.into_raw_fd());
 
@@ -84,7 +88,7 @@ impl DequeueFd for BiQueue {
     }
 }
 
-impl Push<Fd> for BiQueue {
+impl<const SIZE: usize> Push<Fd> for BiQueue<SIZE> {
     fn push(&mut self, item: Fd) -> Result<(), Fd> {
         self.infd.push_back(item);
         Ok(())
@@ -106,76 +110,83 @@ impl EnqueueFd for BiQueue {
 
 // === helper functions ===
 
-fn send_fds(
-    sockfd: RawFd,
-    bufs: &[IoSlice],
-    fds: impl Iterator<Item = RawFd>,
-) -> io::Result<usize> {
-    // Size the buffer to be big enough to hold FD_QUEUE_SIZE RawFd's.
-    // The buffer must be zeroed because subsequent code will not clear padding
-    // bytes.
-    let mut cmsg_buffer = [0u8; cmsg_buffer_fds_space(BiQueue::FD_QUEUE_SIZE)];
+// Currently the type alias below is an error in stable rust. Once
+// #![feature(generic_const_exprs)] is stabalized, though, it may be possible
+// to change to this alias instead of the one based on SmallVec.
+//type CMsgBuffer<const SIZE: usize> = [u8; cmsg_buffer_fds_space(SIZE)];
+type CMsgBuffer = SmallVec<[u8; cmsg_buffer_fds_space(DEFAULT_FD_QUEUE_SIZE)]>;
 
-    let counts = MsgHdr::from_io_slice(bufs, &mut cmsg_buffer)
-        .encode_fds(fds)?
-        .send(sockfd)?;
+impl<const SIZE: usize> BiQueue<SIZE> {
+    fn send_fds(
+        sockfd: RawFd,
+        bufs: &[IoSlice],
+        fds: impl Iterator<Item = RawFd>,
+    ) -> io::Result<usize> {
+        // Size the buffer to be big enough to hold SIZE RawFd's. The buffer
+        // must be zeroed because subsequent code will not clear padding bytes.
+        let mut cmsg_buffer = CMsgBuffer::from_elem(0, cmsg_buffer_fds_space(SIZE));
 
-    trace!(
-        source = "UnixStream",
-        event = "write",
-        fds_count = counts.fds_sent(),
-        byte_count = counts.bytes_sent(),
-    );
+        let counts = MsgHdr::from_io_slice(bufs, &mut cmsg_buffer)
+            .encode_fds(fds)?
+            .send(sockfd)?;
 
-    Ok(counts.bytes_sent())
-}
-
-fn recv_fds(
-    sockfd: RawFd,
-    bufs: &mut [IoSliceMut],
-    fds_sink: &mut impl Push<Fd>,
-) -> io::Result<usize> {
-    // Size the buffer to be big enough to hold FD_QUEUE_SIZE RawFd's.
-    let mut cmsg_buffer = [0u8; cmsg_buffer_fds_space(BiQueue::FD_QUEUE_SIZE)];
-
-    let mut recv = MsgHdr::from_io_slice_mut(bufs, &mut cmsg_buffer).recv(sockfd)?;
-
-    let mut fds_count = 0;
-    for fd in recv.take_fds() {
-        match fds_sink.push(fd) {
-            Ok(_) => fds_count += 1,
-            Err(_) => {
-                warn!(
-                    source = "UnixStream",
-                    event = "read",
-                    condition = "too many fds received"
-                );
-
-                return Err(PushFailureError::new());
-            }
-        }
-    }
-
-    if recv.was_control_truncated() {
-        warn!(
-            source = "UnixStream",
-            event = "read",
-            condition = "cmsgs truncated"
-        );
-
-        Err(CMsgTruncatedError::new())
-    } else {
         trace!(
             source = "UnixStream",
-            event = "read",
-            fds_count,
-            byte_count = recv.bytes_recvieved(),
+            event = "write",
+            fds_count = counts.fds_sent(),
+            byte_count = counts.bytes_sent(),
         );
 
-        Ok(recv.bytes_recvieved())
+        Ok(counts.bytes_sent())
+    }
+
+    fn recv_fds(
+        sockfd: RawFd,
+        bufs: &mut [IoSliceMut],
+        fds_sink: &mut impl Push<Fd>,
+    ) -> io::Result<usize> {
+        // Size the buffer to be big enough to hold SIZE RawFd's. The buffer
+        // must be zeroed because subsequent code will not clear padding bytes.
+        let mut cmsg_buffer = CMsgBuffer::from_elem(0, cmsg_buffer_fds_space(SIZE));
+
+        let mut recv = MsgHdr::from_io_slice_mut(bufs, &mut cmsg_buffer).recv(sockfd)?;
+
+        let mut fds_count = 0;
+        for fd in recv.take_fds() {
+            match fds_sink.push(fd) {
+                Ok(_) => fds_count += 1,
+                Err(_) => {
+                    warn!(
+                        source = "UnixStream",
+                        event = "read",
+                        condition = "too many fds received"
+                    );
+
+                    return Err(PushFailureError::new());
+                }
+            }
+        }
+
+        if recv.was_control_truncated() {
+            warn!(
+                source = "UnixStream",
+                event = "read",
+                condition = "cmsgs truncated"
+            );
+
+            Err(CMsgTruncatedError::new())
+        } else {
+            trace!(
+                source = "UnixStream",
+                event = "read",
+                fds_count,
+                byte_count = recv.bytes_recvieved(),
+            );
+
+            Ok(recv.bytes_recvieved())
+        }
     }
 }
-
 // === impl CMsgTruncatedError ===
 impl CMsgTruncatedError {
     fn new() -> Error {

--- a/src/net.rs
+++ b/src/net.rs
@@ -19,7 +19,7 @@ use std::{
 // needed until the MSRV is 1.43 when the associated constant becomes available
 use std::usize;
 
-use crate::biqueue::BiQueue;
+use crate::biqueue::{self, BiQueue};
 
 use crate::{DequeueFd, EnqueueFd, QueueFullError};
 
@@ -94,7 +94,7 @@ impl UnixStream {
     /// The size of the bounded queue of outbound [`RawFd`][RawFd].
     ///
     /// [RawFd]: https://doc.rust-lang.org/stable/std/os/unix/io/type.RawFd.html
-    pub const FD_QUEUE_SIZE: usize = BiQueue::FD_QUEUE_SIZE;
+    pub const FD_QUEUE_SIZE: usize = biqueue::DEFAULT_FD_QUEUE_SIZE;
 
     /// Connects to the socket named by `path`.
     ///


### PR DESCRIPTION
Add a `SIZE` generic const to `BiQueue` which defaults to `DEFAULT_FD_QUEUE_SIZE` (which is set to 2). This `SIZE` is used for the length of the inbound and outbound queues of fd's. It is also used for the size of the `CMsgBuffer` used as a part of the calls to recvmsg and sendmsg wrapped through `MsgHdr`.

The value of `DEFAULT_FD_QUEUE_SIZE` is chosen to match the old value of `BiQueue::FD_QUEUE_SIZE` to prevent a breaking change.

Currently `CMsgBuffer` is a `SmallVec` with the size of the inline part of the vector based on `DEFAULT_FD_QUEUE_SIZE` (and not on `SIZE`). Current limitations in Rust prevent basing this on `SIZE` (though that may change if `#![feature(generic_const_exprs)]` is stabalized).

This is part of #55.
